### PR TITLE
Implement route for getting an auth token

### DIFF
--- a/app/content/urls.py
+++ b/app/content/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework import routers
+from rest_framework.authtoken.views import obtain_auth_token
 
 from .viewsets import PostsViewSet
 
@@ -25,5 +26,6 @@ route.register('posts', PostsViewSet, basename='Posts')
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api-token-auth/', obtain_auth_token, name='api_token_auth'),
     path('', include(route.urls))
 ]


### PR DESCRIPTION
# Changes Description

Select the type of changes you're doing on project:

- [X] **Feature**
- [ ] **Change**
- [ ] **Fix**
- [ ] **Configuration**



# Solution Descripton

This PR introduces the `POST api-token-auth/` endpoint for getting an authentication token, which must be informed while accessing any other endpoint from this project.


# Tests

This is a well known Django feature. Nonetheless I have tested that the endpoints do not work with no auth token and that they do work with the credentials given by the endpoint introduced in this PR.


# Task

Diana: [Task_32](https://github.com/Try-tech-Labs/diana/tree/32/implement_route_for_getting_an_auth_token)
